### PR TITLE
Add legal filing sample module

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,19 @@ In addition to the packages specified in the table above, the following packages
 - `bazelisk` / `bazel`
 
 See [Dockerfile](Dockerfile) for the full details of installed packages.
+
+## Legal document generator module
+
+This repository includes a simple example module located in `legal_module/` that demonstrates how to generate Traditional Chinese legal filings using the `python-docx` package. The module exposes a `create_filing` function that accepts case information and outputs a formatted Word document.
+
+Example usage:
+
+```bash
+python3 -m legal_module.example
+```
+
+This requires the optional dependency **python-docx**. Install it with:
+
+```bash
+pip install python-docx
+```

--- a/legal_module/example.py
+++ b/legal_module/example.py
@@ -1,0 +1,18 @@
+from .filing import create_filing
+
+sample_case = {
+    'case_number': '臺北地方法院114年度訴字第1234號',
+    'parties': '原告：李灃祐  被告：新鑫公司',
+    'court': '臺灣臺北地方法院',
+    'claims': '請求確認本票債權不存在，並請求返還不當得利新台幣1,000,000元。',
+    'facts': '原告與被告簽署車輛分期契約，惟車輛自始未交付，卻遭告提出票據裁定……',
+    'laws': ['民法第184條', '票據法第17條', '最高法院111年度台上字第3208號判決'],
+    'evidence': [
+        {'id': '乙1', 'summary': 'LINE對話紀錄，顯示告知車輛尚未交付'},
+        {'id': '乙2', 'summary': '川立公司匯款憑證，顯示資金流向'}
+    ]
+}
+
+if __name__ == '__main__':
+    create_filing(sample_case, '法律文書_起訴狀.docx')
+    print('Document generated: 法律文書_起訴狀.docx')

--- a/legal_module/filing.py
+++ b/legal_module/filing.py
@@ -1,0 +1,66 @@
+from typing import Dict
+
+try:
+    from docx import Document
+    from docx.shared import Pt
+except ImportError:  # pragma: no cover - docx may not be installed
+    Document = None
+    Pt = None
+
+class LegalDocumentGenerator:
+    """Generate legal filings in Traditional Chinese."""
+
+    def __init__(self, case_info: Dict[str, any]):
+        self.case_info = case_info
+        if Document is None:
+            raise RuntimeError(
+                "python-docx is required to generate documents. Please install it via 'pip install python-docx'."
+            )
+        self.doc = Document()
+        style = self.doc.styles['Normal']
+        font = style.font
+        font.name = '標楷體'
+        font.size = Pt(16)
+
+    def build(self) -> None:
+        self.doc.add_heading(self.case_info.get('title', '起訴狀'), level=1)
+        self._add_basic_info()
+        self._add_claims()
+        self._add_facts()
+        self._add_laws()
+        self._add_evidence()
+
+    def save(self, filepath: str) -> None:
+        self.doc.save(filepath)
+
+    # Internal helpers
+    def _add_basic_info(self) -> None:
+        self.doc.add_paragraph(f"案號：{self.case_info.get('case_number', '')}")
+        self.doc.add_paragraph(f"當事人：{self.case_info.get('parties', '')}")
+        self.doc.add_paragraph(f"法院：{self.case_info.get('court', '')}")
+
+    def _add_claims(self) -> None:
+        self.doc.add_paragraph("壹、訴之聲明")
+        self.doc.add_paragraph(self.case_info.get('claims', ''))
+
+    def _add_facts(self) -> None:
+        self.doc.add_paragraph("貳、事實與理由")
+        self.doc.add_paragraph(self.case_info.get('facts', ''))
+
+    def _add_laws(self) -> None:
+        self.doc.add_paragraph("參、法律依據")
+        for law in self.case_info.get('laws', []):
+            self.doc.add_paragraph(f"• {law}")
+
+    def _add_evidence(self) -> None:
+        self.doc.add_paragraph("肆、證據目錄")
+        for ev in self.case_info.get('evidence', []):
+            self.doc.add_paragraph(f"【{ev['id']}】{ev['summary']}")
+
+
+def create_filing(case_info: Dict[str, any], output_path: str) -> None:
+    """Helper function to quickly generate a filing document."""
+    generator = LegalDocumentGenerator(case_info)
+    generator.build()
+    generator.save(output_path)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+python-docx


### PR DESCRIPTION
## Summary
- implement legal filing generation module using `python-docx`
- provide sample script that calls the module
- document how to use the module and its dependency
- add `requirements.txt` for optional dependency

## Testing
- `ruff check legal_module/filing.py legal_module/example.py`
- `python3 -m legal_module.example` *(fails: python-docx missing)*

------
https://chatgpt.com/codex/tasks/task_e_683ed9b7b6d083209e9ed91582423501