### PR TITLE
Add legal filing sample module

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ See [Dockerfile](Dockerfile) for the full details of installed packages.
 
 ## Legal document generator module
 
-This repository includes a simple example module located in `legal_module/` that demonstrates how to generate Traditional Chinese legal filings using the `python-docx` package. The module exposes a `create_legal_filing` function that accepts case information and outputs a formatted Word document. The document is formatted with a 2.5 cm margin and 1.5x line spacing.
+This repository includes a simple example module located in `legal_module/` that demonstrates how to generate Traditional Chinese legal filings using the `python-docx` package. The module exposes a `create_legal_filing` function that accepts case information and outputs a formatted Word document. Documents use 2.5 cm margins, 1.5× line spacing and the 標楷體 font. Section numbers are automatically labeled with Chinese numerals.
 
 Example usage:
 
@@ -72,4 +72,5 @@ pip install python-docx docx2pdf
 
 The function returns the path to the generated Word document. When
 ``export_pdf=True`` and ``docx2pdf`` is installed, it returns a tuple with the
-Word and PDF paths.
+Word and PDF paths. A ``FilingType`` enumeration is provided for convenience
+when specifying the desired document style.

--- a/README.md
+++ b/README.md
@@ -53,3 +53,23 @@ In addition to the packages specified in the table above, the following packages
 - `bazelisk` / `bazel`
 
 See [Dockerfile](Dockerfile) for the full details of installed packages.
+
+## Legal document generator module
+
+This repository includes a simple example module located in `legal_module/` that demonstrates how to generate Traditional Chinese legal filings using the `python-docx` package. The module exposes a `create_legal_filing` function that accepts case information and outputs a formatted Word document. The document is formatted with a 2.5 cm margin and 1.5x line spacing.
+
+Example usage:
+
+```bash
+python3 -m legal_module.example
+```
+
+This requires the optional dependency **python-docx**. Install it with:
+
+```bash
+pip install python-docx docx2pdf
+```
+
+The function returns the path to the generated Word document. When
+``export_pdf=True`` and ``docx2pdf`` is installed, it returns a tuple with the
+Word and PDF paths.

--- a/legal_module/__init__.py
+++ b/legal_module/__init__.py
@@ -1,5 +1,5 @@
 """Public API for the legal document generator."""
 
-from .filing import create_legal_filing
+from .filing import create_legal_filing, FilingType
 
-__all__ = ["create_legal_filing"]
+__all__ = ["create_legal_filing", "FilingType"]

--- a/legal_module/__init__.py
+++ b/legal_module/__init__.py
@@ -1,0 +1,5 @@
+"""Public API for the legal document generator."""
+
+from .filing import create_legal_filing
+
+__all__ = ["create_legal_filing"]

--- a/legal_module/example.py
+++ b/legal_module/example.py
@@ -1,0 +1,24 @@
+"""Example usage of the legal filing generator."""
+
+from .filing import create_legal_filing
+
+sample_case = {
+    'case_number': '臺北地方法院114年度訴字第1234號',
+    'parties': '原告：李灃祐  被告：新鑫公司',
+    'court': '臺灣臺北地方法院',
+    'claims': '請求確認本票債權不存在，並請求返還不當得利新台幣1,000,000元。',
+    'facts': '原告與被告簽署車輛分期契約，惟車輛自始未交付，卻遭告提出票據裁定……',
+    'laws': ['民法第184條', '票據法第17條', '最高法院111年度台上字第3208號判決'],
+    'evidence': [
+        {'id': '乙1', 'summary': 'LINE對話紀錄，顯示告知車輛尚未交付'},
+        {'id': '乙2', 'summary': '川立公司匯款憑證，顯示資金流向'}
+    ]
+}
+
+if __name__ == '__main__':
+    path = create_legal_filing(sample_case)
+    if isinstance(path, tuple):
+        word_path, pdf_path = path
+        print(f'Document generated: {word_path} and {pdf_path}')
+    else:
+        print(f'Document generated: {path}')

--- a/legal_module/example.py
+++ b/legal_module/example.py
@@ -1,11 +1,12 @@
 """Example usage of the legal filing generator."""
 
-from .filing import create_legal_filing
+from .filing import create_legal_filing, FilingType
 
 sample_case = {
     'case_number': '臺北地方法院114年度訴字第1234號',
     'parties': '原告：李灃祐  被告：新鑫公司',
     'court': '臺灣臺北地方法院',
+    'filing_type': FilingType.COMPLAINT.value,
     'claims': '請求確認本票債權不存在，並請求返還不當得利新台幣1,000,000元。',
     'facts': '原告與被告簽署車輛分期契約，惟車輛自始未交付，卻遭告提出票據裁定……',
     'laws': ['民法第184條', '票據法第17條', '最高法院111年度台上字第3208號判決'],

--- a/legal_module/filing.py
+++ b/legal_module/filing.py
@@ -1,0 +1,129 @@
+"""Generate Traditional Chinese legal documents using python-docx."""
+
+from typing import List, Tuple, Union, TypedDict
+
+
+class EvidenceEntry(TypedDict):
+    """A single evidence item."""
+
+    id: str
+    summary: str
+
+
+class CaseInfo(TypedDict, total=False):
+    """Information required for generating a legal document."""
+
+    title: str
+    case_number: str
+    parties: str
+    court: str
+    claims: str
+    facts: str
+    laws: List[str]
+    evidence: List[EvidenceEntry]
+
+try:  # pragma: no cover - optional dependency may be missing
+    from docx import Document
+    from docx.shared import Pt, Cm
+    from docx.enum.text import WD_LINE_SPACING
+except ImportError:  # pragma: no cover - docx may not be installed
+    Document = None
+    Pt = None
+    Cm = None
+    WD_LINE_SPACING = None
+
+try:  # pragma: no cover - optional dependency
+    from docx2pdf import convert as docx2pdf_convert
+except Exception:  # pragma: no cover - docx2pdf is truly optional
+    docx2pdf_convert = None
+
+class LegalDocumentGenerator:
+    """Generate legal filings in Traditional Chinese."""
+
+    def __init__(self, case_info: CaseInfo):
+        self.case_info = case_info
+        if Document is None:
+            raise RuntimeError(
+                "python-docx is required to generate documents. Please install it via 'pip install python-docx'."
+            )
+        self.doc = Document()
+        style = self.doc.styles["Normal"]
+        font = style.font
+        font.name = "標楷體"
+        font.size = Pt(16)
+        style.paragraph_format.line_spacing = 1.5
+        for section in self.doc.sections:
+            section.top_margin = Cm(2.5)
+            section.bottom_margin = Cm(2.5)
+            section.left_margin = Cm(2.5)
+            section.right_margin = Cm(2.5)
+
+    def build(self) -> None:
+        self.doc.add_heading(self.case_info.get('title', '起訴狀'), level=1)
+        self._add_basic_info()
+        self._add_claims()
+        self._add_facts()
+        self._add_laws()
+        self._add_evidence()
+
+    def save(self, filepath: str) -> None:
+        self.doc.save(filepath)
+
+    # Internal helpers
+    def _add_basic_info(self) -> None:
+        self.doc.add_paragraph(f"案號：{self.case_info.get('case_number', '')}")
+        self.doc.add_paragraph(f"當事人：{self.case_info.get('parties', '')}")
+        self.doc.add_paragraph(f"法院：{self.case_info.get('court', '')}")
+
+    def _add_claims(self) -> None:
+        self.doc.add_paragraph("壹、訴之聲明")
+        self.doc.add_paragraph(self.case_info.get('claims', ''))
+
+    def _add_facts(self) -> None:
+        self.doc.add_paragraph("貳、事實與理由")
+        self.doc.add_paragraph(self.case_info.get('facts', ''))
+
+    def _add_laws(self) -> None:
+        self.doc.add_paragraph("參、法律依據")
+        for law in self.case_info.get('laws', []):
+            self.doc.add_paragraph(f"• {law}")
+
+    def _add_evidence(self) -> None:
+        self.doc.add_paragraph("肆、證據目錄")
+        for ev in self.case_info.get('evidence', []):
+            self.doc.add_paragraph(f"【{ev['id']}】{ev['summary']}")
+
+
+def create_legal_filing(
+    case_info: CaseInfo,
+    output_path: str = "法律文書_起訴狀.docx",
+    *,
+    export_pdf: bool = False,
+) -> Union[str, Tuple[str, str]]:
+    """Create a legal filing as a Word document.
+
+    Parameters
+    ----------
+    case_info:
+        Case details used to populate the document.
+    output_path:
+        Path to the generated Word document.
+    export_pdf:
+        If ``True`` and ``docx2pdf`` is installed, also export a PDF.
+    """
+
+    generator = LegalDocumentGenerator(case_info)
+    generator.build()
+    generator.save(output_path)
+
+    if export_pdf:
+        if docx2pdf_convert is None:
+            raise RuntimeError(
+                "docx2pdf is required for exporting PDF. Install it via 'pip install docx2pdf'."
+            )
+        pdf_path = output_path.rsplit(".", 1)[0] + ".pdf"
+        docx2pdf_convert(output_path, pdf_path)
+        return output_path, pdf_path
+
+    return output_path
+

--- a/legal_module/filing.py
+++ b/legal_module/filing.py
@@ -1,5 +1,7 @@
 """Generate Traditional Chinese legal documents using python-docx."""
 
+from __future__ import annotations
+
 from typing import List, Tuple, Union, TypedDict
 from enum import Enum
 
@@ -23,17 +25,15 @@ class CaseInfo(TypedDict, total=False):
     laws: List[str]
     evidence: List[EvidenceEntry]
 
-    filing_type: str  # optional; defaults to ``FilingType.COMPLAINT``
+    filing_type: FilingType | str  # optional; defaults to ``FilingType.COMPLAINT``
 
 try:  # pragma: no cover - optional dependency may be missing
     from docx import Document
     from docx.shared import Pt, Cm
-    from docx.enum.text import WD_LINE_SPACING
 except ImportError:  # pragma: no cover - docx may not be installed
     Document = None
     Pt = None
     Cm = None
-    WD_LINE_SPACING = None
 
 try:  # pragma: no cover - optional dependency
     from docx2pdf import convert as docx2pdf_convert

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+python-docx
+docx2pdf


### PR DESCRIPTION
## Summary
- implement legal filing generation module using `python-docx`
- provide sample script that calls the module
- document how to use the module and its dependency
- add `requirements.txt` for optional dependency
- refine legal filing generator

## Testing
- `ruff check legal_module/filing.py legal_module/example.py legal_module/__init__.py`
- `python3 -m legal_module.example` *(fails: python-docx missing)*

------
https://chatgpt.com/codex/tasks/task_e_683ed9b7b6d083209e9ed91582423501