### PR TITLE
Add PDF export to legal filing generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ See [Dockerfile](Dockerfile) for the full details of installed packages.
 
 ## Legal document generator module
 
-This repository includes a simple example module located in `legal_module/` that demonstrates how to generate Traditional Chinese legal filings using the `python-docx` package. The module exposes a `create_filing` function that accepts case information and outputs a formatted Word document.
+This repository includes a simple example module located in `legal_module/` that demonstrates how to generate Traditional Chinese legal filings using the `python-docx` package. The module exposes a `create_filing` function that accepts case information and outputs a formatted Word document. If `docx2pdf` is installed, the document can also be exported to PDF.
 
 Example usage:
 
@@ -64,8 +64,8 @@ Example usage:
 python3 -m legal_module.example
 ```
 
-This requires the optional dependency **python-docx**. Install it with:
+This requires the optional dependencies **python-docx** and **docx2pdf** for PDF export. Install them with:
 
 ```bash
-pip install python-docx
+pip install python-docx docx2pdf
 ```

--- a/legal_module/example.py
+++ b/legal_module/example.py
@@ -10,9 +10,12 @@ sample_case = {
     'evidence': [
         {'id': '乙1', 'summary': 'LINE對話紀錄，顯示告知車輛尚未交付'},
         {'id': '乙2', 'summary': '川立公司匯款憑證，顯示資金流向'}
+    ],
+    'attachments': [
+        {'id': '附件一', 'description': '車輛分期契約影本'},
     ]
 }
 
 if __name__ == '__main__':
-    create_filing(sample_case, '法律文書_起訴狀.docx')
-    print('Document generated: 法律文書_起訴狀.docx')
+    create_filing(sample_case, '法律文書_起訴狀.docx', pdf_path='法律文書_起訴狀.pdf')
+    print('Documents generated: 法律文書_起訴狀.docx, 法律文書_起訴狀.pdf')

--- a/legal_module/filing.py
+++ b/legal_module/filing.py
@@ -1,8 +1,10 @@
-from typing import Dict
+from typing import Any, Dict, Optional
+from pathlib import Path
+import tempfile
 
 try:
     from docx import Document
-    from docx.shared import Pt
+    from docx.shared import Pt, Cm
 except ImportError:  # pragma: no cover - docx may not be installed
     Document = None
     Pt = None
@@ -10,17 +12,24 @@ except ImportError:  # pragma: no cover - docx may not be installed
 class LegalDocumentGenerator:
     """Generate legal filings in Traditional Chinese."""
 
-    def __init__(self, case_info: Dict[str, any]):
+    def __init__(self, case_info: Dict[str, Any]):
         self.case_info = case_info
         if Document is None:
             raise RuntimeError(
                 "python-docx is required to generate documents. Please install it via 'pip install python-docx'."
             )
         self.doc = Document()
-        style = self.doc.styles['Normal']
+        style = self.doc.styles["Normal"]
         font = style.font
-        font.name = '標楷體'
+        font.name = "標楷體"
         font.size = Pt(16)
+        style.paragraph_format.line_spacing = Pt(24)  # 1.5 line spacing
+
+        for section in self.doc.sections:
+            section.top_margin = Cm(2.5)
+            section.bottom_margin = Cm(2.5)
+            section.left_margin = Cm(2.5)
+            section.right_margin = Cm(2.5)
 
     def build(self) -> None:
         self.doc.add_heading(self.case_info.get('title', '起訴狀'), level=1)
@@ -29,9 +38,24 @@ class LegalDocumentGenerator:
         self._add_facts()
         self._add_laws()
         self._add_evidence()
+        self._add_attachments()
 
     def save(self, filepath: str) -> None:
         self.doc.save(filepath)
+
+    def save_pdf(self, filepath: str) -> None:
+        """Save the generated document as a PDF using docx2pdf if available."""
+        try:
+            from docx2pdf import convert
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError(
+                "docx2pdf is required for PDF export. Install it via 'pip install docx2pdf'."
+            ) from exc
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            docx_path = Path(tmpdir) / "temp.docx"
+            self.doc.save(docx_path)
+            convert(str(docx_path), filepath)
 
     # Internal helpers
     def _add_basic_info(self) -> None:
@@ -57,10 +81,36 @@ class LegalDocumentGenerator:
         for ev in self.case_info.get('evidence', []):
             self.doc.add_paragraph(f"【{ev['id']}】{ev['summary']}")
 
+    def _add_attachments(self) -> None:
+        attachments = self.case_info.get("attachments")
+        if not attachments:
+            return
+        self.doc.add_paragraph("伍、附件")
+        for att in attachments:
+            desc = att.get("description", "")
+            att_id = att.get("id", "")
+            self.doc.add_paragraph(f"【{att_id}】{desc}")
 
-def create_filing(case_info: Dict[str, any], output_path: str) -> None:
-    """Helper function to quickly generate a filing document."""
+
+def create_filing(
+    case_info: Dict[str, Any],
+    output_path: str,
+    pdf_path: Optional[str] = None,
+) -> None:
+    """Helper function to quickly generate a filing document.
+
+    Parameters
+    ----------
+    case_info : Dict[str, Any]
+        Information about the case.
+    output_path : str
+        Location to write the DOCX file.
+    pdf_path : Optional[str]
+        If provided, also export the document to this PDF path.
+    """
     generator = LegalDocumentGenerator(case_info)
     generator.build()
     generator.save(output_path)
+    if pdf_path:
+        generator.save_pdf(pdf_path)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 python-docx
+docx2pdf


### PR DESCRIPTION
## Summary
- allow PDF export with `docx2pdf`
- set 2.5cm margins and 1.5 line spacing
- support attachments section
- update example and documentation
- add `docx2pdf` to requirements
- fix typing annotations

## Testing
- `ruff check legal_module`
- `python3 -m legal_module.example` *(fails: python-docx not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683ee8ea02d48320a1ea2a387780e8af